### PR TITLE
ユーザー固有の設定をsetting.iniに書くようにした

### DIFF
--- a/bookmark.py
+++ b/bookmark.py
@@ -15,19 +15,17 @@ class NarouBookmark:
 
     def __init__(self):
         self.session = requests.Session()
-        inifile = configparser.ConfigParser()
-        inifile.read('./setting.ini', 'UTF-8')
-        self.narouid = inifile.get('narou', 'id')
-        self.password = inifile.get('narou', 'pass')
 
     def login_narou(self):
         """
         なろうにログインする
         """
         # メールアドレスとパスワードの指定
+        inifile = configparser.ConfigParser()
+        inifile.read("./setting.ini")
         login_info = {
-            "narouid": self.narouid,
-            "pass": self.password
+            "narouid": inifile.get("narou", "id"),
+            "pass": inifile.get("narou", "pass")
         }
         # なろうURL
         login_url = "https://ssl.syosetu.com/login/login/"

--- a/bookmark.py
+++ b/bookmark.py
@@ -4,6 +4,7 @@ import requests
 from bs4 import BeautifulSoup
 from urllib import parse
 import pandas
+import configparser
 
 
 class NarouBookmark:
@@ -14,17 +15,19 @@ class NarouBookmark:
 
     def __init__(self):
         self.session = requests.Session()
+        inifile = configparser.ConfigParser()
+        inifile.read('./setting.ini', 'UTF-8')
+        self.narouid = inifile.get('narou', 'id')
+        self.password = inifile.get('narou', 'pass')
 
     def login_narou(self):
         """
         なろうにログインする
         """
         # メールアドレスとパスワードの指定
-        narouid = ""
-        password = ""
         login_info = {
-            "narouid": narouid,
-            "pass": password
+            "narouid": self.narouid,
+            "pass": self.password
         }
         # なろうURL
         login_url = "https://ssl.syosetu.com/login/login/"

--- a/setting.ini
+++ b/setting.ini
@@ -3,4 +3,3 @@
     pass = naroupassword
 [yahoo]
     appid = yahooappid
-    

--- a/setting.ini
+++ b/setting.ini
@@ -1,0 +1,6 @@
+[narou]
+    id = naouid
+    pass = naroupassword
+[yahoo]
+    appid = yahooappid
+    


### PR DESCRIPTION
目的：うっかりIDやパスワードをソースに書いたままコミットするのを防止するため
変更点：ユーザー固有の設定（なろうのログイン ID・パスワード、YahooのアプリケーションID）をsetting.iniに記載し、configparserで読み込むようにしました。

